### PR TITLE
time: Make SystemTime::now() use the correct time unit

### DIFF
--- a/src/time.rs
+++ b/src/time.rs
@@ -99,7 +99,7 @@ impl SystemTime {
     pub const UNIX_EPOCH: SystemTime = UNIX_EPOCH;
 
     pub fn now() -> SystemTime {
-        let us = (js_sys::Date::now() * 1000000f64) as u64;
+        let us = (js_sys::Date::now() * 1000f64) as u64;
         SystemTime(us)
     }
 


### PR DESCRIPTION
The previous conversion stored the timestamp as nanoseconds, instead of microseconds as the codebase expects.

According to MDN
> The Date.now() static method returns the number of milliseconds elapsed since the epoch
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now

The issue has been detected while comparing SystemTime::now() timestamps generated by a Linux executable with timestamps generated by kywasmtime.

SystemTime::now().as_micros() results:
* Linux std::time::SystemTime:  1738590492673999872
* kywasmtime::time::SystemTime: 1738590493317670