### PR TITLE
Use saturating addition to allow sleeping for `Duration::MAX`

### DIFF
--- a/src/sleep.rs
+++ b/src/sleep.rs
@@ -71,7 +71,7 @@ impl Future for Sleep {
                 return Poll::Ready(());
             }
 
-            let duration_ms: i32 = (this.deadline - now).as_millis().try_into().unwrap();
+            let duration_ms: i32 = (this.deadline - now).as_millis().try_into().unwrap_or(i32::MAX);
 
             // Flag set when the promise is resolved
             let resolved = Rc::new(RefCell::new(false));

--- a/src/time.rs
+++ b/src/time.rs
@@ -7,6 +7,8 @@ use wasm_bindgen::JsCast;
 pub struct Instant(u64);
 
 impl Instant {
+    pub const MAX: Self = Self(u64::MAX);
+
     pub fn now() -> Self {
         let global = js_sys::global();
         let global_scope = global.unchecked_ref::<js::GlobalScope>();
@@ -57,7 +59,7 @@ impl Add<Duration> for Instant {
 
     fn add(self, other: Duration) -> Self::Output {
         self.checked_add(other)
-            .expect("overflow when adding duration to instant")
+            .unwrap_or(Self::MAX)
     }
 }
 


### PR DESCRIPTION
With checked addition, sleeping for `Duration::MAX` (or other large values, the precise boundary of which is nondeterministic!) causes a panic.

This patch uses saturating addition instead, so that `Duration::MAX` can be used as a safe approximation of infinity.