### PR TITLE
expose `Elapsed`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,4 @@
+/// Error returned by [crate::timeout][`timeout`] if the timeout
+/// elapses before the future completes.
+#[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
+pub struct Elapsed;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod error;
 mod interval;
 mod js;
 mod sleep;

--- a/src/timeout.rs
+++ b/src/timeout.rs
@@ -1,3 +1,4 @@
+use crate::error::Elapsed;
 use crate::sleep::{sleep, sleep_until, Sleep};
 use crate::time::Instant;
 use std::future::{Future, IntoFuture};
@@ -38,8 +39,6 @@ impl<T: Future> Future for Timeout<T> {
         }
     }
 }
-
-pub struct Elapsed; // Error returned by Timeout
 
 pub fn timeout_at<F>(deadline: Instant, future: F) -> Timeout<F::IntoFuture>
 where


### PR DESCRIPTION
The `timeout` API returns a `Result<T, Elapsed>` but `Elapsed` isn't exposed from the crate, so can't be named.

Instead, expose it at a location mirroring Tokio's (`error::Elapsed`).